### PR TITLE
Update Printer.hx

### DIFF
--- a/src/haxeprinter/Printer.hx
+++ b/src/haxeprinter/Printer.hx
@@ -40,7 +40,7 @@ class Printer
 		if (style == null) style = SNormal;
 
 		lineLen += s.length;
-		#if js
+		#if (js && !noStyle)
 		var style = Std.string(style).substr(1).toLowerCase();
 		line.add('<span class="$style">$s</span>');
 		#else


### PR DESCRIPTION
-D noStyle to make it optionally output just plain formatted text for js

I just use it for HIDE. Already added it. Syntax highlighting is awesome, better than in any editor, but I'm not sure how to use it as mode for some editor.
