### PR TITLE
Expression tests

### DIFF
--- a/build.hxml
+++ b/build.hxml
@@ -27,6 +27,6 @@
 
 # --next
 
-# -cp unit
-# -main Test
-# --interp
+-cp unit
+-main Test
+--interp

--- a/src/haxeprinter/Formatter.hx
+++ b/src/haxeprinter/Formatter.hx
@@ -26,7 +26,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		{
 			before = switch (token.tok)
 			{
-				case Dot | POpen | PClose | Const(_) | Const(CIdent(_)) | Kwd(KwdFalse) | 
+				case Dot | POpen | PClose | Const(_) | Const(CIdent(_)) | Kwd(KwdFalse) |
 					Kwd(KwdTrue) | Kwd(KwdNull): SNone;
 				case Semicolon | DblDot: SNone;
 				default: SIgnore;
@@ -895,7 +895,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 			case [{tok:Binop(op)}]:
 				var around = switch (op)
 				{
-					case OpAssignOp(_):
+					case OpAssign | OpAssignOp(_):
 						spaceIf(cfg.space_around_assignment_operators);
 					case OpBoolAnd | OpBoolOr:
 						spaceIf(cfg.space_around_logical_operators);

--- a/unit/Test.hx
+++ b/unit/Test.hx
@@ -2,7 +2,7 @@ class Test {
 	static public function main() {
 		var runner = new haxe.unit.TestRunner();
 		runner.add(new TestExpr());
-		runner.add(new TestFile());
+		//runner.add(new TestFile());
 		runner.run();
 	}
 }

--- a/unit/TestCommon.hx
+++ b/unit/TestCommon.hx
@@ -4,24 +4,26 @@ import haxeprinter.Config;
 @:access(haxeprinter.Formatter)
 class TestCommon extends haxe.unit.TestCase {
 		
-	function exprEq(sourceCode:String, config:Config, expectedCode:String, ?p:haxe.PosInfos) {
-		var s = parseExpr(sourceCode, config, p);
+	var currentConfig:Config;
+	
+	function exprEq(sourceCode:String, expectedCode:String, ?p:haxe.PosInfos) {
+		var s = parseExpr(sourceCode, p);
 		assertEquals(expectedCode, s, p);
 	}
 	
-	function fileEq(sourceCode:String, config:Config, expectedCode:String, ?p:haxe.PosInfos) {
-		var s = parseFile(sourceCode, config, p);
+	function fileEq(sourceCode:String, expectedCode:String, ?p:haxe.PosInfos) {
+		var s = parseFile(sourceCode, p);
 		assertEquals(expectedCode, s, p);
 	}
 	
-	static function parseExpr(inputCode:String, config:Config, ?p:haxe.PosInfos) {
-		var parser = new Formatter(byte.ByteData.ofString(inputCode), config, '${p.methodName}:${p.lineNumber}');
+	function parseExpr(inputCode:String, ?p:haxe.PosInfos) {
+		var parser = new Formatter(byte.ByteData.ofString(inputCode), currentConfig, '${p.methodName}:${p.lineNumber}');
 		parser.parseExpr();
 		return parser.getContent();
 	}
 	
-	static function parseFile(inputCode:String, config:Config, ?p:haxe.PosInfos) {
-		var parser = new Formatter(byte.ByteData.ofString(inputCode), config, '${p.methodName}:${p.lineNumber}');
+	function parseFile(inputCode:String, ?p:haxe.PosInfos) {
+		var parser = new Formatter(byte.ByteData.ofString(inputCode), currentConfig, '${p.methodName}:${p.lineNumber}');
 		parser.parseFile();
 		return parser.getContent();
 	}

--- a/unit/TestExpr.hx
+++ b/unit/TestExpr.hx
@@ -1,5 +1,7 @@
 import haxeprinter.Config;
 
+import TestFileMacro.test;
+
 class TestExpr extends TestCommon {
 	
 	static var defaultConfig:Config = {
@@ -9,37 +11,323 @@ class TestExpr extends TestCommon {
 		config;
 	}
 	
-	function test_space_between_function_args() {
-		var config2 = Reflect.copy(defaultConfig);
-		config2.space_between_function_args = false;
-		
-		exprEq("a(   b,   c)", defaultConfig, "a(b, c)");
-		exprEq("a(   b,   c)", config2, "a(b,c)");
-		
-		exprEq("new A(   b,   c)", defaultConfig, "new A(b, c)");
-		exprEq("new B(   b,   c)", config2, "new B(b,c)");
+	static function copyConfig() {
+		return Reflect.copy(defaultConfig);
+	}
+	
+	override function setup() {
+		currentConfig = copyConfig();
+	}
+	
+	function test_space_before_method_call_parenthesis() {
+		test(
+			["a()", "a(b)", "a(b,c)"],
+			space_before_method_call_parenthesis = true,
+			["a ()", "a (b)", "a (b,c)"]
+		);
+	}
+	
+	function test_space_before_if_parenthesis() {
+		test(
+			"if (a) {}",
+			space_before_if_parenthesis = false,
+			"if(a) {}"
+		);
+	}
+	
+	function test_space_before_for_parenthesis() {
+		test(
+			"for (a) {}",
+			space_before_for_parenthesis = false,
+			"for(a) {}"
+		);
+	}
+	
+	function test_space_before_while_parenthesis() {
+		test(
+			["while (a) {}", "do {} while (a)"],
+			space_before_while_parenthesis = false,
+			["while(a) {}", "do {} while(a)"]
+		);
+	}
+
+	function test_space_before_switch_parenthesis() {
+		test(
+			"switch (a) {}",
+			space_before_switch_parenthesis = false,
+			"switch(a) {}"
+		);
+	}
+	
+	function test_space_before_catch_parenthesis() {
+		test(
+			"try {} catch (b:C) {}",
+			space_before_catch_parenthesis = false,
+			"try {} catch(b:C) {}"
+		);
+	}
+	
+	function test_space_around_assignment_operators() {
+		test(
+			["x = 1", "var x = 1", "function x(x = 1) {}"],
+			space_around_assignment_operators = false,
+			["x=1", "var x=1", "function x(x=1) {}"]
+		);
+	}
+	
+	function test_space_around_logical_operators() {
+		test(
+			["1 || 2", "1 && 2"],
+			space_around_logical_operators = false,
+			["1||2", "1&&2"]
+		);
+	}
+	
+	function test_space_around_equality_operators() {
+		test(
+			["1 == 2", "1 != 2"],
+			space_around_equality_operators = false,
+			["1==2", "1!=2"]
+		);
+	}
+	
+	function test_space_around_relational_operators() {
+		test(
+			["1 > 2", "1 >= 2", "1 < 2", "1 <= 2"],
+			space_around_relational_operators = false,
+			["1>2", "1>=2", "1<2", "1<=2"]
+		);
+	}
+	
+	function test_space_around_additive_operators() {
+		test(
+			["1 + 2", "1 - 2"],
+			space_around_additive_operators = false,
+			["1+2", "1-2"]
+		);
+	}
+	
+	function test_space_around_multiplicative_operators() {
+		test(
+			["1 * 2", "1 / 2", "1 % 2"],
+			space_around_multiplicative_operators = false,
+			["1*2", "1/2", "1%2"]
+		);
+	}
+	
+	function test_space_before_method_left_brace() {
+		test(
+			"function() {}",
+			space_before_method_left_brace = false,
+			"function(){}"
+		);
+	}
+	
+	function test_space_before_if_left_brace() {
+		test(
+			"if (a) {}",
+			space_before_if_left_brace = false,
+			"if (a){}"
+		);
+	}
+	
+	function test_space_before_else_left_brace() {
+		test(
+			"if (a) {} else {}",
+			space_before_else_left_brace = false,
+			"if (a) {} else{}"
+		);
+	}
+	
+	//function test_space_before_for_left_brace() {
+		//test(
+			//"for (a) {}",
+			//space_before_for_left_brace = false,
+			//"for (a){}"
+		//);
+	//}
+	
+	function test_space_before_while_left_brace() {
+		test(
+			"while (a) {}",
+			space_before_while_left_brace = false,
+			"while (a){}"
+		);
+	}
+	
+	//function test_space_before_switch_left_brace() {
+		//test(
+			//"switch (a) {}",
+			//space_before_switch_left_brace = false,
+			//"switch (a){}"
+		//);
+	//}
+	
+	//function test_space_before_try_left_brace() {
+		//test(
+			//"try {} catch(a:B) {}",
+			//space_before_try_left_brace = false,
+			//"try{} catch(a:B) {}"
+		//);
+	//}
+	
+	function test_space_before_catch_left_brace() {
+		test(
+			"try {} catch (a:B) {}",
+			space_before_catch_left_brace = false,
+			"try {} catch (a:B){}"
+		);
+	}
+	
+	//function test_space_before_else_keyword() {
+		//test(
+			//["if (a) {} else {}", "if (a)b else {}"],
+			//space_before_else_keyword = false,
+			//["if (a) {}else {}", "if (a)b else {}"]
+		//);
+	//}
+	
+	//function test_space_before_while_keyword() {
+		//test(
+			//["do {} while (a)", "do a while (b)"],
+			//space_before_while_keyword = false,
+			//["do {}while (a)", "do a while (b)"]
+		//);
+	//}
+	
+	//function test_space_before_catch_keyword() {
+		//test(
+			//["try {} catch (a:B) {}", "try a catch (b:B) {}"],
+			//space_before_catch_keyword = false,
+			//["try {}catch (b:B) {}", "try a catch (b:B) {}"]
+		//);
+	//}
+	
+	function test_space_within_method_call_parenthesis() {
+		test(
+			["a()", "a(b)", "a(b,c)"],
+			space_within_method_call_parenthesis = true,
+			["a( )", "a( b )", "a( b,c )"]
+		);
+	}
+	
+	function test_space_within_method_declaration_parenthesis() {
+		test(
+			["function() {}", "function(a) {}", "function(a, b)"],
+			space_within_method_declaration_parenthesis = true,
+			["function( ) {}", "function( a ) {}", "function( a, b )"]
+		);
+	}
+	
+	function test_space_within_if_parenthesis() {
+		test(
+			"if (a) {}",
+			space_within_if_parenthesis = true,
+			"if ( a ) {}"
+		);
+	}
+	
+	function test_space_within_for_parenthesis() {
+		test(
+			"for (a) {}",
+			space_within_for_parenthesis = true,
+			"for ( a ) {}"
+		);
+	}
+	
+	//function test_space_within_while_parenthesis() {
+		//test(
+			//["while (a) {}", "do {} while (a)"],
+			//space_within_while_parenthesis = true,
+			//["while ( a ) {}", "do {} while ( a )"]
+		//);
+	//}
+	
+	//function test_space_within_switch_parenthesis() {
+		//test(
+			//"switch (a) {}",
+			//space_within_switch_parenthesis = true,
+			//"switch ( a ) {}"
+		//);
+	//}
+	
+	//function test_space_within_catch_parenthesis() {
+		//test(
+			//"try {} catch(a:B) {}",
+			//space_within_catch_parenthesis = true,
+			//"try {} catch( a:B ) {}"
+		//);
+	//}
+	
+	function test_space_in_ternary() {
+		test(
+			"a?b:c",
+			space_in_ternary_before_question = true,
+			"a ?b:c",
+			space_in_ternary_after_question = true,
+			"a ? b:c",
+			space_in_ternary_before_colon = true,
+			"a ? b :c",
+			space_in_ternary_after_colon = true,
+			"a ? b : c"
+		);
+	}
+	
+	function test_space_around_arrow() {
+		test(
+			["(x:a -> b)", "(x:a -> b -> c)"],
+			space_around_arrow = false,
+			["(x:a->b)", "(x:a->b->c)"]
+		);
 	}
 	
 	function test_space_before_type_hint_colon() {
-		var config2 = Reflect.copy(defaultConfig);
-		config2.space_before_type_hint_colon = true;
-		
-		exprEq("var x :   Int", defaultConfig, "var x:Int");
-		exprEq("var x :   Int", config2, "var x :Int");
-		
-		exprEq("function ():Int", defaultConfig, "function ():Int");
-		exprEq("var x :   Int", config2, "var x :Int");
-		
-		exprEq(" (x : Int)", defaultConfig, "(x:Int)");
-		exprEq(" (x : Int)", config2, "(x :Int)");
+		test(
+			["(a:B)", "var a:B", "function():A {}"],
+			space_before_type_hint_colon = true,
+			["(a :B)", "var a :B", "function() :A {}"]
+		);
 	}
 	
 	function test_space_after_type_hint_colon() {
-		var config2 = Reflect.copy(defaultConfig);
-		config2.space_after_type_hint_colon = true;
-		
-		exprEq("var x :   Int", config2, "var x: Int");
-		exprEq("var x :   Int", config2, "var x: Int");
-		exprEq(" (x : Int)", config2, "(x: Int)");
+		test(
+			["(a:B)", "var a:B", "function():A {}"],
+			space_after_type_hint_colon = true,
+			["(a: B)", "var a: B", "function(): A {}"]
+		);
 	}
+	
+	function test_space_between_type_parameters() {
+		test(
+			["function a<A>() {}", "function a<A, B>() {}", "function a<A, B, C>() {}"],
+			space_between_type_parameters = false,
+			["function a<A>() {}", "function a<A,B>() {}", "function a<A,B,C>() {}"]
+		);
+	}
+	
+	function test_space_between_function_arguments() {
+		test(
+			["function a() {}", "function a(b) {}", "function a(b, c) {}"],
+			space_between_function_arguments = false,
+			["function a() {}", "function a(b) {}", "function a(b,c) {}"]
+		);
+	}
+	
+	//function test_space_between_call_arguments() {
+		//test(
+			//["a()", "a(b)", "a(b, c)"],
+			//space_between_call_arguments = false,
+			//["a()", "a(b)", "a(b,c)"]
+		//);
+	//}
+	
+	function test_space_between_type_constraints() {
+		test(
+			["function a<B:C>() {}", "function a<B:(C, D)>() {}"],
+			space_between_type_constraints = false,
+			["function a<B:C>() {}", "function a<B:(C,D)>() {}"]
+		);
+	}
+
+	// TODO: space_between_var_declarations (requires blocks)
 }

--- a/unit/TestFileMacro.hx
+++ b/unit/TestFileMacro.hx
@@ -64,4 +64,30 @@ class TestFileMacro {
 		}).fields[0];
 		return field;
 	}
+	
+	macro static public function test(eSubjects:ExprOf<Array<String>>, el:Array<Expr>) {
+		var subjects = switch (eSubjects.expr) {
+			case EArrayDecl(el): el;
+			case _: [eSubjects];
+		}
+		var ret = [];
+		el.unshift(eSubjects);
+		for (e in el) {
+			switch (e) {
+				case macro $a{el}:
+					if (el.length != subjects.length) {
+						Context.error("Invalid array length, should be " +subjects.length, e.pos);
+					}
+					for (i in 0...subjects.length) {
+						ret.push(macro exprEq($e{subjects[i]}, $e{el[i]}));
+					}
+				case macro $i{lhs} = $rhs:
+					ret.push(macro currentConfig.$lhs = $rhs);
+				case _:
+					ret.push(macro exprEq($e{subjects[0]}, $e));
+			}
+		}
+		var e = macro $b{ret};
+		return e;
+	}
 }


### PR DESCRIPTION
Here's a first batch. I left the failing ones commented out so it's easier to check individual ones.

You might break some tests by fixing others, in which case the input for that source has to be adapted. The most prominent example for that is probably spaces between call arguments, which doesn't seem to work.
