### PR TITLE
fix various spacings

### DIFF
--- a/src/haxeprinter/Formatter.hx
+++ b/src/haxeprinter/Formatter.hx
@@ -780,9 +780,9 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 			case [{tok:Kwd(KwdFor)}]:
 				addLast(SKwd);
 				expect(POpen, null, spaceIf(cfg.space_before_for_parenthesis), spaceIf(cfg.space_within_for_parenthesis));
-				parseExpr(spaceIf(cfg.space_before_for_left_brace));
-				expect(PClose, spaceIf(cfg.space_within_for_parenthesis));
 				parseExpr();
+				expect(PClose, spaceIf(cfg.space_within_for_parenthesis));
+				parseExpr(spaceIf(cfg.space_before_for_left_brace));
 			case [{tok:Kwd(KwdWhile)}]:
 				addLast(SKwd, spaceIf(cfg.space_before_while_keyword));
 				expect(POpen, null, spaceIf(cfg.space_before_while_parenthesis), spaceIf(cfg.space_within_while_parenthesis));
@@ -793,9 +793,9 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				addLast(SKwd);
 				parseExpr(spaceIf(cfg.space_before_while_left_brace));
 				expect(Kwd(KwdWhile), SKwd, spaceIf(cfg.space_before_while_keyword));
-				expect(POpen, null, spaceIf(cfg.space_before_while_parenthesis));
+				expect(POpen, null, spaceIf(cfg.space_before_while_parenthesis), spaceIf(cfg.space_within_while_parenthesis));
 				parseExpr();
-				expect(PClose);
+				expect(PClose, null, spaceIf(cfg.space_within_while_parenthesis));
 			case [{tok:Unop(op)}]:
 				addLast(null, spaceIf(cfg.space_around_unary_operators));
 				parseExpr();
@@ -808,9 +808,15 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				plist(parseCatch);
 			case [{tok:Kwd(KwdSwitch)}]:
 				addLast(SKwd, null, spaceIf(cfg.space_before_switch_parenthesis));
-				// TODO: space_within_switch_parenthesis
-				parseExpr();
-				expect(BrOpen, null);
+				switch stream {
+					case [{tok:POpen}]:
+						addLast(null, null, spaceIf(cfg.space_within_switch_parenthesis));
+						parseExpr();
+						expect(PClose, null, spaceIf(cfg.space_within_switch_parenthesis));
+					case _:
+						parseExpr();
+				}
+				expect(BrOpen, spaceIf(cfg.space_before_switch_left_brace));
 				moreTabs();
 				while(true) {
 					switch stream {
@@ -868,7 +874,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		switch stream {
 			case [{tok:POpen}]:
 				addLast(null, spaceIf(cfg.space_before_method_call_parenthesis), spaceIf(cfg.space_within_method_call_parenthesis));
-				psep(Comma, parseExpr.bind(null, null));
+				psep(Comma, parseExpr.bind(null, null), null, spaceIf(cfg.space_between_call_arguments));
 				expect(PClose, spaceIf(cfg.space_within_method_call_parenthesis));
 				parseExprNext();
 			case [{tok:Dot}]:

--- a/unit/TestExpr.hx
+++ b/unit/TestExpr.hx
@@ -21,9 +21,9 @@ class TestExpr extends TestCommon {
 	
 	function test_space_before_method_call_parenthesis() {
 		test(
-			["a()", "a(b)", "a(b,c)"],
+			["a()", "a(b)", "a(b, c)"],
 			space_before_method_call_parenthesis = true,
-			["a ()", "a (b)", "a (b,c)"]
+			["a ()", "a (b)", "a (b, c)"]
 		);
 	}
 	
@@ -139,13 +139,13 @@ class TestExpr extends TestCommon {
 		);
 	}
 	
-	//function test_space_before_for_left_brace() {
-		//test(
-			//"for (a) {}",
-			//space_before_for_left_brace = false,
-			//"for (a){}"
-		//);
-	//}
+	function test_space_before_for_left_brace() {
+		test(
+			"for (a) {}",
+			space_before_for_left_brace = false,
+			"for (a){}"
+		);
+	}
 	
 	function test_space_before_while_left_brace() {
 		test(
@@ -155,21 +155,21 @@ class TestExpr extends TestCommon {
 		);
 	}
 	
-	//function test_space_before_switch_left_brace() {
-		//test(
-			//"switch (a) {}",
-			//space_before_switch_left_brace = false,
-			//"switch (a){}"
-		//);
-	//}
+	function test_space_before_switch_left_brace() {
+		test(
+			"switch (a) {}",
+			space_before_switch_left_brace = false,
+			"switch (a){}"
+		);
+	}
 	
-	//function test_space_before_try_left_brace() {
-		//test(
-			//"try {} catch(a:B) {}",
-			//space_before_try_left_brace = false,
-			//"try{} catch(a:B) {}"
-		//);
-	//}
+	function test_space_before_try_left_brace() {
+		test(
+			"try {} catch (a:B) {}",
+			space_before_try_left_brace = false,
+			"try{} catch (a:B) {}"
+		);
+	}
 	
 	function test_space_before_catch_left_brace() {
 		test(
@@ -205,9 +205,9 @@ class TestExpr extends TestCommon {
 	
 	function test_space_within_method_call_parenthesis() {
 		test(
-			["a()", "a(b)", "a(b,c)"],
+			["a()", "a(b)", "a(b, c)"],
 			space_within_method_call_parenthesis = true,
-			["a( )", "a( b )", "a( b,c )"]
+			["a( )", "a( b )", "a( b, c )"]
 		);
 	}
 	
@@ -235,29 +235,29 @@ class TestExpr extends TestCommon {
 		);
 	}
 	
-	//function test_space_within_while_parenthesis() {
-		//test(
-			//["while (a) {}", "do {} while (a)"],
-			//space_within_while_parenthesis = true,
-			//["while ( a ) {}", "do {} while ( a )"]
-		//);
-	//}
+	function test_space_within_while_parenthesis() {
+		test(
+			["while (a) {}", "do {} while (a)"],
+			space_within_while_parenthesis = true,
+			["while ( a ) {}", "do {} while ( a )"]
+		);
+	}
 	
-	//function test_space_within_switch_parenthesis() {
-		//test(
-			//"switch (a) {}",
-			//space_within_switch_parenthesis = true,
-			//"switch ( a ) {}"
-		//);
-	//}
+	function test_space_within_switch_parenthesis() {
+		test(
+			"switch (a) {}",
+			space_within_switch_parenthesis = true,
+			"switch ( a ) {}"
+		);
+	}
 	
-	//function test_space_within_catch_parenthesis() {
-		//test(
-			//"try {} catch(a:B) {}",
-			//space_within_catch_parenthesis = true,
-			//"try {} catch( a:B ) {}"
-		//);
-	//}
+	function test_space_within_catch_parenthesis() {
+		test(
+			"try {} catch (a:B) {}",
+			space_within_catch_parenthesis = true,
+			"try {} catch ( a:B ) {}"
+		);
+	}
 	
 	function test_space_in_ternary() {
 		test(
@@ -313,13 +313,13 @@ class TestExpr extends TestCommon {
 		);
 	}
 	
-	//function test_space_between_call_arguments() {
-		//test(
-			//["a()", "a(b)", "a(b, c)"],
-			//space_between_call_arguments = false,
-			//["a()", "a(b)", "a(b,c)"]
-		//);
-	//}
+	function test_space_between_call_arguments() {
+		test(
+			["a()", "a(b)", "a(b, c)"],
+			space_between_call_arguments = false,
+			["a()", "a(b)", "a(b,c)"]
+		);
+	}
 	
 	function test_space_between_type_constraints() {
 		test(


### PR DESCRIPTION
I fixed everything I could.

There are still issues with the "space before keyword" ones because I'm not sure these are valid. You will find that `if (a)b else {}` becomes `if (a)belse {}`, which is a case where there absolutely must be a space before the `else`.
