### PR TITLE
build.hxml fix

### DIFF
--- a/build.hxml
+++ b/build.hxml
@@ -1,3 +1,8 @@
+-cp src
+--macro haxeprinter.Macro.generateConfigTemplate()
+
+--next
+
 -cmd cp res/* bin
 
 --next
@@ -11,7 +16,9 @@
 
 --each
 
---macro haxeprinter.Macro.generateConfigTemplate()
+
+--next
+
 -main haxeprinter.Main
 -neko bin/format.n
 


### PR DESCRIPTION
Currently you cannot compile from a fresh clone because the default config is missing. We have to generate it before doing anything else.
