### PR TITLE
use nested config instead of flat one

### DIFF
--- a/src/haxeprinter/Config.hx
+++ b/src/haxeprinter/Config.hx
@@ -1,175 +1,184 @@
 package haxeprinter;
 
+typedef ConfigSpaceAfter = {
+	@:default(false)
+	var type_hint_colon:Bool;
+}
+
+typedef ConfigSpaceAround = {
+	@:default(true)
+	var assignment_operators:Bool;
+
+	@:default(true)
+	var logical_operators:Bool;
+
+	@:default(true)
+	var equality_operators:Bool;
+
+	@:default(true)
+	var relational_operators:Bool;
+
+	@:default(true)
+	var additive_operators:Bool;
+
+	@:default(true)
+	var multiplicative_operators:Bool;
+
+	@:default(false)
+	var unary_operators:Bool;
+	
+	@:default(true)
+	var arrow:Bool;
+}
+
+typedef ConfigSpaceBefore = {
+	@:default(false)
+	var method_declaration_parenthesis:Bool;
+	
+	@:default(false)
+	var method_call_parenthesis:Bool;
+
+	@:default(true)
+	var if_parenthesis:Bool;
+
+	@:default(true)
+	var for_parenthesis:Bool;
+
+	@:default(true)
+	var while_parenthesis:Bool;
+
+	@:default(true)
+	var switch_parenthesis:Bool;
+
+	@:default(true)
+	var catch_parenthesis:Bool;
+
+	@:default(true)
+	var method_left_brace:Bool;
+
+	@:default(true)
+	var if_left_brace:Bool;
+
+	@:default(true)
+	var else_left_brace:Bool;
+
+	@:default(true)
+	var for_left_brace:Bool;
+
+	@:default(true)
+	var while_left_brace:Bool;
+
+	@:default(true)
+	var switch_left_brace:Bool;
+
+	@:default(true)
+	var try_left_brace:Bool;
+
+	@:default(true)
+	var catch_left_brace:Bool;
+
+	@:default(true)
+	var else_keyword:Bool;
+
+	@:default(true)
+	var while_keyword:Bool;
+
+	@:default(true)
+	var catch_keyword:Bool;
+
+	@:default(false)
+	var type_hint_colon:Bool;
+}
+
+typedef ConfigSpaceBetween = {
+	@:default(true)
+	var type_parameters:Bool;
+
+	@:default(true)
+	var function_arguments:Bool;
+
+	@:default(true)
+	var call_arguments:Bool;
+
+	@:default(true)
+	var enum_arguments:Bool;
+
+	@:default(true)
+	var type_constraints:Bool;
+
+	@:default(true)
+	var var_declarations:Bool;
+}
+
+typedef ConfigSpaceWithin = {
+	@:default(false)
+	var method_call_parenthesis:Bool;
+
+	@:default(false)
+	var method_declaration_parenthesis:Bool;
+
+	@:default(false)
+	var if_parenthesis:Bool;
+
+	@:default(false)
+	var for_parenthesis:Bool;
+
+	@:default(false)
+	var while_parenthesis:Bool;
+
+	@:default(false)
+	var switch_parenthesis:Bool;
+
+	@:default(false)
+	var catch_parenthesis:Bool;
+
+	@:default(false)
+	var ternary_before_question:Bool;
+
+	@:default(false)
+	var ternary_after_question:Bool;
+
+	@:default(false)
+	var ternary_before_colon:Bool;
+
+	@:default(false)
+	var ternary_after_colon:Bool;
+}
+
+typedef ConfigSpace = {
+	var after:ConfigSpaceAfter;
+	
+	var around:ConfigSpaceAround;
+	
+	var before:ConfigSpaceBefore;
+	
+	var between:ConfigSpaceBetween;
+	
+	var within:ConfigSpaceWithin;
+	
+	@:default(true)
+	var condense_multiple:Bool;
+}
+
+typedef ConfigNewline = {
+	@:default(true)
+	var condense_multiple:Bool;
+	
+	@:default(true)
+	var empty_at_end_of_file:Bool;
+
+	@:default(false)
+	var before_brace:Bool;
+
+	@:default(false)
+	var before_extends:Bool;
+
+	@:default(false)
+	var before_implements:Bool;
+}
+
 typedef Config =
 {
-	@:default(true)
-	var condense_multiple_spaces:Bool;
-
-	@:default(true)
-	var condense_multiple_empty_lines:Bool;
-
-	@:default(true)
-	var empty_line_at_end_of_file:Bool;
-
-	// space
-
-	// before parenthesis
-
-	@:default(false)
-	var space_before_method_declaration_parenthesis:Bool;
-
-	@:default(false)
-	var space_before_method_call_parenthesis:Bool;
-
-	@:default(true)
-	var space_before_if_parenthesis:Bool;
-
-	@:default(true)
-	var space_before_for_parenthesis:Bool;
-
-	@:default(true)
-	var space_before_while_parenthesis:Bool;
-
-	@:default(true)
-	var space_before_switch_parenthesis:Bool;
-
-	@:default(true)
-	var space_before_catch_parenthesis:Bool;
-
-	// around operators
-
-	@:default(true)
-	var space_around_assignment_operators:Bool;
-
-	@:default(true)
-	var space_around_logical_operators:Bool;
-
-	@:default(true)
-	var space_around_equality_operators:Bool;
-
-	@:default(true)
-	var space_around_relational_operators:Bool;
-
-	@:default(true)
-	var space_around_additive_operators:Bool;
-
-	@:default(true)
-	var space_around_multiplicative_operators:Bool;
-
-	@:default(false)
-	var space_around_unary_operators:Bool;
-
-	// before left brace
-
-	@:default(true)
-	var space_before_method_left_brace:Bool;
-
-	@:default(true)
-	var space_before_if_left_brace:Bool;
-
-	@:default(true)
-	var space_before_else_left_brace:Bool;
-
-	@:default(true)
-	var space_before_for_left_brace:Bool;
-
-	@:default(true)
-	var space_before_while_left_brace:Bool;
-
-	@:default(true)
-	var space_before_switch_left_brace:Bool;
-
-	@:default(true)
-	var space_before_try_left_brace:Bool;
-
-	@:default(true)
-	var space_before_catch_left_brace:Bool;
-
-	// before keywords
-
-	@:default(true)
-	var space_before_else_keyword:Bool;
-
-	@:default(true)
-	var space_before_while_keyword:Bool;
-
-	@:default(true)
-	var space_before_catch_keyword:Bool;
-
-	// within
-
-	@:default(false)
-	var space_within_method_call_parenthesis:Bool;
-
-	@:default(false)
-	var space_within_method_declaration_parenthesis:Bool;
-
-	@:default(false)
-	var space_within_if_parenthesis:Bool;
-
-	@:default(false)
-	var space_within_for_parenthesis:Bool;
-
-	@:default(false)
-	var space_within_while_parenthesis:Bool;
-
-	@:default(false)
-	var space_within_switch_parenthesis:Bool;
-
-	@:default(false)
-	var space_within_catch_parenthesis:Bool;
-
-	// in ternary
-
-	@:default(false)
-	var space_in_ternary_before_question:Bool;
-
-	@:default(false)
-	var space_in_ternary_after_question:Bool;
-
-	@:default(false)
-	var space_in_ternary_before_colon:Bool;
-
-	@:default(false)
-	var space_in_ternary_after_colon:Bool;
-
-	// other
-
-	@:default(true)
-	var space_around_arrow:Bool;
-
-	@:default(false)
-	var space_before_type_hint_colon:Bool;
-
-	@:default(false)
-	var space_after_type_hint_colon:Bool;
-
-	@:default(true)
-	var space_between_type_parameters:Bool;
-
-	@:default(true)
-	var space_between_function_arguments:Bool;
-
-	@:default(true)
-	var space_between_call_arguments:Bool;
-
-	@:default(true)
-	var space_between_enum_arguments:Bool;
-
-	@:default(true)
-	var space_between_type_constraints:Bool;
-
-	@:default(true)
-	var space_between_var_declarations:Bool;
-
-	// cuddle braces
-
-	@:default(false)
-	var brace_on_newline:Bool;
-
-	@:default(false)
-	var extends_on_newline:Bool;
-
-	@:default(false)
-	var implements_on_newline:Bool;
+	var newline:ConfigNewline;
+	var space:ConfigSpace;
 }

--- a/src/haxeprinter/Demo.hx
+++ b/src/haxeprinter/Demo.hx
@@ -7,7 +7,7 @@ import hxparse.Unexpected;
 
 class Demo
 {
-	static var cfg;
+	static var cfg:Config;
 	
 	static function main()
 	{
@@ -26,22 +26,36 @@ class Demo
 		}
 		
 		var html = '<form>';
-		for (field in Reflect.fields(cfg))
-		{
-			var label = field.split('_').join(' ');
-			var value = Reflect.field(cfg, field);
-			if (value == true || value == false)
+		function loop(obj:{}, path:String) {
+			for (field in Reflect.fields(obj))
 			{
-				var checked = value ? ' checked' : '';
-				html += '<fieldset><input type="checkbox" name="$field"$checked/></input<label for="$field">$label</label></fieldset>';
+				var label = field.split('_').join(' ');
+				var value:Dynamic = Reflect.field(obj, field);
+				var name = path == "" ? field : path + "." + field;
+				if (value == true || value == false)
+				{
+					var checked = value ? ' checked' : '';
+					html += '<fieldset><input type="checkbox" name="$name"$checked/></input<label for="$field">$label</label></fieldset>';
+				} else {
+					// TODO: I guess not all non-bool fields are sub-categories
+					html += "<ul>" + label;
+					loop(value, name);
+					html += "</ul>";
+				}
 			}
 		}
+		loop(cfg, "");
 		config.innerHTML = html + '</form>';
 		config.onclick = function(e) {
 			if (e.target.tagName != 'INPUT') return;
-			var name = e.target.getAttribute('name');
+			var name:String = e.target.getAttribute('name');
 			var value = e.target.checked;
-			Reflect.setField(cfg, name, value);
+			var split = name.split(".");
+			var obj = cfg;
+			while(split.length > 1) {
+				obj = Reflect.field(obj, split.shift());
+			}
+			Reflect.setField(obj, split.shift(), value);
 			update();
 		}
 

--- a/src/haxeprinter/Formatter.hx
+++ b/src/haxeprinter/Formatter.hx
@@ -22,8 +22,8 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	function add(token:Token, ?style:Style, ?before:Spacing, ?after:Spacing)
 	{
 		var space = token.space;
-		if (cfg.condense_multiple_spaces) space = ~/ +/.replace(space, ' ');
-		if (cfg.condense_multiple_empty_lines) space = ~/\n{3,}/.replace(space, '\n\n');
+		if (cfg.space.condense_multiple) space = ~/ +/.replace(space, ' ');
+		if (cfg.newline.condense_multiple) space = ~/\n{3,}/.replace(space, '\n\n');
 		space = ~/(^|\n)[\t ]{2,}/.replace(space, '$$1$tabs');
 		var newline = space.indexOf('\n') > -1;
 
@@ -52,7 +52,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		{
 			case SSpace:
 				// if (newline) space;
-				// else 
+				// else
 				if (lastChar == ' ') '';
 				else ' ';
 			case SNewline: '\n$tabs';
@@ -136,7 +136,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	{
 		parseFile();
 		var output = StringTools.trim(buf.toString());
-		if (cfg.empty_line_at_end_of_file) output += '\n';
+		if (cfg.newline.empty_at_end_of_file) output += '\n';
 		return output;
 	}
 
@@ -221,7 +221,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	function parseTypeHint() {
 		switch stream {
 			case [{tok:DblDot}]:
-				addLast(spaceIf(cfg.space_before_type_hint_colon), spaceIf(cfg.space_after_type_hint_colon));
+				addLast(spaceIf(cfg.space.before.type_hint_colon), spaceIf(cfg.space.after.type_hint_colon));
 				parseComplexType();
 		}
 	}
@@ -229,7 +229,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	function parseAssignment() {
 		switch stream {
 			case [{tok:Binop(OpAssign)}]:
-				var around = spaceIf(cfg.space_around_assignment_operators);
+				var around = spaceIf(cfg.space.around.assignment_operators);
 				addLast(null, around, around);
 				parseExpr();
 		}
@@ -239,11 +239,11 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		addLast(SKwd);
 		popt(parseAnyIdent.bind(null, SSpace));
 		popt(parseTypeParameters);
-		expect(POpen, null, spaceIf(cfg.space_before_method_declaration_parenthesis), spaceIf(cfg.space_within_method_declaration_parenthesis));
-		psep(Comma, parseFunctionArgument, null, spaceIf(cfg.space_between_function_arguments));
-		expect(PClose, spaceIf(cfg.space_within_method_declaration_parenthesis));
+		expect(POpen, null, spaceIf(cfg.space.before.method_declaration_parenthesis), spaceIf(cfg.space.within.method_declaration_parenthesis));
+		psep(Comma, parseFunctionArgument, null, spaceIf(cfg.space.between.function_arguments));
+		expect(PClose, spaceIf(cfg.space.within.method_declaration_parenthesis));
 		popt(parseTypeHint);
-		popt(parseExpr.bind(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_method_left_brace), null));
+		popt(parseExpr.bind(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.method_left_brace), null));
 	}
 
 	function parseFunctionArgument() {
@@ -275,7 +275,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		switch stream {
 			case [{tok:POpen}]:
 				addLast();
-				psep(Comma, parseExpr.bind(null, null), null, spaceIf(cfg.space_between_call_arguments));
+				psep(Comma, parseExpr.bind(null, null), null, spaceIf(cfg.space.between.call_arguments));
 				expect(PClose);
 		}
 	}
@@ -343,7 +343,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				parseAnyIdent(SType, SSpace);
 				popt(parseTypeParameters);
 				parseHeritance();
-				expect(BrOpen, spaceOrNewline(cfg.brace_on_newline, true));
+				expect(BrOpen, spaceOrNewline(cfg.newline.before_brace, true));
 				moreTabs();
 				parseClassFields(false);
 				
@@ -352,7 +352,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				parseAnyIdent(SType, SSpace);
 				popt(parseTypeParameters);
 
-				expect(BrOpen, spaceOrNewline(cfg.brace_on_newline, true));
+				expect(BrOpen, spaceOrNewline(cfg.newline.before_brace, true));
 				moreTabs();
 				parseEnumFields(false);
 
@@ -370,7 +370,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				popt(parseAbstractThis);
 				popt(parseAbstractRelations);
 
-				expect(BrOpen, spaceOrNewline(cfg.brace_on_newline, true));
+				expect(BrOpen, spaceOrNewline(cfg.newline.before_brace, true));
 				moreTabs();
 				parseEnumFields(false);
 			case [{tok:Eof}]:
@@ -383,7 +383,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		switch stream {
 			case [{tok:Binop(OpLt)}]:
 				addLast();
-				psep(Comma, parseTypeParameter, null, spaceIf(cfg.space_between_type_parameters));
+				psep(Comma, parseTypeParameter, null, spaceIf(cfg.space.between.type_parameters));
 				expect(Binop(OpGt));
 		}
 	}
@@ -400,7 +400,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				switch stream {
 					case [{tok:POpen}]:
 						addLast();
-						psep(Comma, parseComplexType, null, spaceIf(cfg.space_between_type_constraints));
+						psep(Comma, parseComplexType, null, spaceIf(cfg.space.between.type_constraints));
 						expect(PClose);
 					case [_ = parseComplexType()]:
 				}
@@ -413,10 +413,10 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		while(true) {
 			switch stream {
 				case [{tok:Kwd(KwdExtends)}]:
-					addLast(SDecl, cfg.extends_on_newline ? SNewlineIndented : SSpace, SSpace);
+					addLast(SDecl, cfg.newline.before_extends ? SNewlineIndented : SSpace, SSpace);
 					parseComplexType();
 				case [{tok:Kwd(KwdImplements)}]:
-					addLast(SDecl, cfg.implements_on_newline ? SNewlineIndented : SSpace, SSpace);
+					addLast(SDecl, cfg.newline.before_implements ? SNewlineIndented : SSpace, SSpace);
 					parseComplexType();
 				case _: break;
 			}
@@ -480,7 +480,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		switch stream {
 			case [{tok:POpen}]:
 				addLast();
-				psep(Comma, parseFunctionArgument, null, spaceIf(cfg.space_between_enum_arguments));
+				psep(Comma, parseFunctionArgument, null, spaceIf(cfg.space.between.enum_arguments));
 				expect(PClose);
 			case _:
 		}
@@ -525,7 +525,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				parseDotPath();
 			case [{tok:Binop(OpLt)}]:
 				addLast();
-				psep(Comma, parseComplexType, null, spaceIf(cfg.space_between_type_parameters));
+				psep(Comma, parseComplexType, null, spaceIf(cfg.space.between.type_parameters));
 				expect(Binop(OpGt));
 		}
 	}
@@ -562,7 +562,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	function parseComplexTypeNext() {
 		switch stream {
 			case [{tok:Arrow}]:
-				var around = spaceIf(cfg.space_around_arrow);
+				var around = spaceIf(cfg.space.around.arrow);
 				addLast(SKwd, around, around);
 				parseComplexType();
 		}
@@ -600,11 +600,11 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	function parseMacroExpr() {
 		switch stream {
 			case [{tok:DblDot}]:
-				addLast(spaceIf(cfg.space_before_type_hint_colon), spaceIf(cfg.space_after_type_hint_colon));
+				addLast(spaceIf(cfg.space.before.type_hint_colon), spaceIf(cfg.space.after.type_hint_colon));
 				parseComplexType();
 			case [{tok:Kwd(KwdVar)}]:
 				addLast(SKwd);
-				psep(Comma, parseVarDeclaration, null, spaceIf(cfg.space_between_var_declarations));
+				psep(Comma, parseVarDeclaration, null, spaceIf(cfg.space.between.var_declarations));
 			case [_ = parseExpr()]:
 		}
 	}
@@ -612,13 +612,13 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	function parseCatch() {
 		switch stream {
 			case [{tok:Kwd(KwdCatch)}]:
-				addLast(SKwd, spaceOrNewline(cfg.brace_on_newline, cfg.space_before_catch_keyword));
-				expect(POpen, null, spaceIf(cfg.space_before_catch_parenthesis), spaceIf(cfg.space_within_catch_parenthesis));
+				addLast(SKwd, spaceOrNewline(cfg.newline.before_brace, cfg.space.before.catch_keyword));
+				expect(POpen, null, spaceIf(cfg.space.before.catch_parenthesis), spaceIf(cfg.space.within.catch_parenthesis));
 				parseAnyIdent();
 				expect(DblDot);
 				parseComplexType();
-				expect(PClose, spaceIf(cfg.space_within_catch_parenthesis));
-				parseExpr(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_catch_left_brace));
+				expect(PClose, spaceIf(cfg.space.within.catch_parenthesis));
+				parseExpr(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.catch_left_brace));
 		}
 	}
 	
@@ -626,7 +626,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 		switch stream {
 			case [{tok:Kwd(KwdVar)}]:
 				addLast(SKwd);
-				psep(Comma, parseVarDeclaration, null, spaceIf(cfg.space_between_var_declarations));
+				psep(Comma, parseVarDeclaration, null, spaceIf(cfg.space.between.var_declarations));
 				semicolon();
 			case [_ = parseExpr()]:
 				semicolon();
@@ -763,7 +763,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				parseExpr();
 				switch stream {
 					case [{tok:DblDot}]:
-						addLast(spaceIf(cfg.space_before_type_hint_colon), spaceIf(cfg.space_after_type_hint_colon));
+						addLast(spaceIf(cfg.space.before.type_hint_colon), spaceIf(cfg.space.after.type_hint_colon));
 						parseComplexType();
 						expect(PClose);
 					case [{tok:PClose}]:
@@ -773,15 +773,15 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				}
 			case[{tok:Kwd(KwdIf)}]:
 				addLast(SKwd);
-				expect(POpen, null, spaceIf(cfg.space_before_if_parenthesis), spaceIf(cfg.space_within_if_parenthesis));
+				expect(POpen, null, spaceIf(cfg.space.before.if_parenthesis), spaceIf(cfg.space.within.if_parenthesis));
 				parseExpr();
-				expect(PClose, spaceIf(cfg.space_within_if_parenthesis));
-				parseExpr(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_if_left_brace));
+				expect(PClose, spaceIf(cfg.space.within.if_parenthesis));
+				parseExpr(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.if_left_brace));
 				semicolon();
 				switch stream {
 					case [{tok:Kwd(KwdElse)}]:
-						addLast(SKwd, spaceOrNewline(cfg.brace_on_newline, cfg.space_before_else_keyword));
-						parseExpr(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_else_left_brace));
+						addLast(SKwd, spaceOrNewline(cfg.newline.before_brace, cfg.space.before.else_keyword));
+						parseExpr(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.else_left_brace));
 					case _:
 				}
 			case [{tok:Kwd(KwdNew)}]:
@@ -792,44 +792,44 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				expect(PClose);
 			case [{tok:Kwd(KwdFor)}]:
 				addLast(SKwd);
-				expect(POpen, null, spaceIf(cfg.space_before_for_parenthesis), spaceIf(cfg.space_within_for_parenthesis));
+				expect(POpen, null, spaceIf(cfg.space.before.for_parenthesis), spaceIf(cfg.space.within.for_parenthesis));
 				parseExpr();
-				expect(PClose, spaceIf(cfg.space_within_for_parenthesis));
-				parseExpr(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_for_left_brace));
+				expect(PClose, spaceIf(cfg.space.within.for_parenthesis));
+				parseExpr(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.for_left_brace));
 			case [{tok:Kwd(KwdWhile)}]:
 				addLast(SKwd);
-				expect(POpen, null, spaceIf(cfg.space_before_while_parenthesis), spaceIf(cfg.space_within_while_parenthesis));
+				expect(POpen, null, spaceIf(cfg.space.before.while_parenthesis), spaceIf(cfg.space.within.while_parenthesis));
 				parseExpr();
-				expect(PClose, spaceIf(cfg.space_within_while_parenthesis));
-				parseExpr(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_while_left_brace));
+				expect(PClose, spaceIf(cfg.space.within.while_parenthesis));
+				parseExpr(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.while_left_brace));
 			case [{tok:Kwd(KwdDo)}]:
 				addLast(SKwd);
-				parseExpr(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_while_left_brace));
-				expect(Kwd(KwdWhile), SKwd, spaceOrNewline(cfg.brace_on_newline, cfg.space_before_while_keyword));
-				expect(POpen, null, spaceIf(cfg.space_before_while_parenthesis), spaceIf(cfg.space_within_while_parenthesis));
+				parseExpr(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.while_left_brace));
+				expect(Kwd(KwdWhile), SKwd, spaceOrNewline(cfg.newline.before_brace, cfg.space.before.while_keyword));
+				expect(POpen, null, spaceIf(cfg.space.before.while_parenthesis), spaceIf(cfg.space.within.while_parenthesis));
 				parseExpr();
-				expect(PClose, spaceIf(cfg.space_within_while_parenthesis));
+				expect(PClose, spaceIf(cfg.space.within.while_parenthesis));
 			case [{tok:Unop(op)}]:
-				addLast(null, spaceIf(cfg.space_around_unary_operators));
+				addLast(null, spaceIf(cfg.space.around.unary_operators));
 				parseExpr();
 			case [{tok:IntInterval(s)}]:
 				addLast();
 				parseExpr();
 			case [{tok:Kwd(KwdTry)}]:
 				addLast(SKwd);
-				parseExpr(spaceOrNewline(cfg.brace_on_newline, cfg.space_before_try_left_brace));
+				parseExpr(spaceOrNewline(cfg.newline.before_brace, cfg.space.before.try_left_brace));
 				plist(parseCatch);
 			case [{tok:Kwd(KwdSwitch)}]:
-				addLast(SKwd, null, spaceIf(cfg.space_before_switch_parenthesis));
+				addLast(SKwd, null, spaceIf(cfg.space.before.switch_parenthesis));
 				switch stream {
 					case [{tok:POpen}]:
-						addLast(null, null, spaceIf(cfg.space_within_switch_parenthesis));
+						addLast(null, null, spaceIf(cfg.space.within.switch_parenthesis));
 						parseExpr();
-						expect(PClose, null, spaceIf(cfg.space_within_switch_parenthesis));
+						expect(PClose, null, spaceIf(cfg.space.within.switch_parenthesis));
 					case _:
 						parseExpr();
 				}
-				expect(BrOpen, spaceOrNewline(cfg.brace_on_newline, cfg.space_before_switch_left_brace));
+				expect(BrOpen, spaceOrNewline(cfg.newline.before_brace, cfg.space.before.switch_left_brace));
 				moreTabs();
 				while(true) {
 					switch stream {
@@ -886,9 +886,9 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 	function parseExprNext() {
 		switch stream {
 			case [{tok:POpen}]:
-				addLast(null, spaceIf(cfg.space_before_method_call_parenthesis), spaceIf(cfg.space_within_method_call_parenthesis));
-				psep(Comma, parseExpr.bind(null, null), null, spaceIf(cfg.space_between_call_arguments));
-				expect(PClose, spaceIf(cfg.space_within_method_call_parenthesis));
+				addLast(null, spaceIf(cfg.space.before.method_call_parenthesis), spaceIf(cfg.space.within.method_call_parenthesis));
+				psep(Comma, parseExpr.bind(null, null), null, spaceIf(cfg.space.between.call_arguments));
+				expect(PClose, spaceIf(cfg.space.within.method_call_parenthesis));
 				parseExprNext();
 			case [{tok:Dot}]:
 				addLast();
@@ -903,7 +903,7 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 						case [{tok:Binop(OpAssign)}]:
 							toks.push(last);
 						case _:
-							var space = spaceIf(toks.length < 3 ? cfg.space_around_relational_operators : cfg.space_around_assignment_operators);
+							var space = spaceIf(toks.length < 3 ? cfg.space.around.relational_operators : cfg.space.around.assignment_operators);
 							for (i in 0...toks.length)
 								add(toks[i], null, i == 0 ? space : null, i == toks.length - 1 ? space : null);
 							parseExpr();
@@ -915,17 +915,17 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				var around = switch (op)
 				{
 					case OpAssign | OpAssignOp(_):
-						spaceIf(cfg.space_around_assignment_operators);
+						spaceIf(cfg.space.around.assignment_operators);
 					case OpBoolAnd | OpBoolOr:
-						spaceIf(cfg.space_around_logical_operators);
+						spaceIf(cfg.space.around.logical_operators);
 					case OpEq | OpNotEq:
-						spaceIf(cfg.space_around_equality_operators);
+						spaceIf(cfg.space.around.equality_operators);
 					case OpLt | OpGt | OpGte | OpLte:
-						spaceIf(cfg.space_around_relational_operators);
+						spaceIf(cfg.space.around.relational_operators);
 					case OpAdd | OpSub:
-						spaceIf(cfg.space_around_additive_operators);
+						spaceIf(cfg.space.around.additive_operators);
 					case OpMult | OpDiv | OpMod:
-						spaceIf(cfg.space_around_multiplicative_operators);
+						spaceIf(cfg.space.around.multiplicative_operators);
 					default:
 						null;
 				}
@@ -942,13 +942,13 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 				expect(BkClose);
 				parseExprNext();
 			case [{tok:Question}]:
-				addLast(spaceIf(cfg.space_in_ternary_before_question), spaceIf(cfg.space_in_ternary_after_question));
+				addLast(spaceIf(cfg.space.within.ternary_before_question), spaceIf(cfg.space.within.ternary_after_question));
 				parseExpr();
-				expect(DblDot, spaceIf(cfg.space_in_ternary_before_colon), spaceIf(cfg.space_in_ternary_after_colon));
+				expect(DblDot, spaceIf(cfg.space.within.ternary_before_colon), spaceIf(cfg.space.within.ternary_after_colon));
 				parseExpr();
 				parseExprNext();
 			case [{tok:Unop(op)}]:
-				addLast(null, spaceIf(cfg.space_around_unary_operators));
+				addLast(null, spaceIf(cfg.space.around.unary_operators));
 				parseExprNext();
 			case _:
 		}

--- a/src/haxeprinter/Macro.hx
+++ b/src/haxeprinter/Macro.hx
@@ -6,24 +6,33 @@ import haxe.macro.Type;
 
 using haxe.macro.Tools;
 using Lambda;
+using StringTools;
 
 class Macro {
 	static public function generateConfigTemplate() {
-		var t = Context.getType("haxeprinter.Config");
-		var sFields = [];
-		switch(t.follow()) {
-			case TAnonymous(anon):
-				var fields = anon.get().fields;
-				for (field in fields) {
-					var def = field.meta.get().find(function(meta) return meta.name == ":default");
-					var sDef = def.params[0].toString();
-					sFields.push('"${field.name}":$sDef');
-				}
-			case _:
-				throw false;
+		function loop(t:Type, path, tabs) {
+			var sFields = [];
+			var l = path.split(".").length + 1;
+			var tabs2 = tabs + "\t";
+			switch(t.follow()) {
+				case TAnonymous(anon):
+					var fields = anon.get().fields;
+					for (field in fields) {
+						var def = field.meta.get().find(function(meta) return meta.name == ":default");
+						var s = if (def == null) {
+							" " + loop(field.type, path == "" ? field.name : '$path.${field.name}', tabs2);
+						} else {
+							def.params[0].toString();
+						}
+						sFields.push('$tabs2"${field.name}": $s');
+					}
+				case _:
+					throw false;
+			}
+			sFields.sort(function(s1, s2) return if (s1.endsWith("}")) -1 else if (s2.endsWith("}")) 1 else Reflect.compare(s1,s2));
+			return "{\n" + sFields.join(",\n") + "\n" + tabs + "}";
 		}
-		sFields.sort(Reflect.compare);
-		var s = "{\n\t" + sFields.join(",\n\t") + "\n}";
+		var s = loop(Context.getType("haxeprinter.Config"), "", "");
 		sys.io.File.saveContent("res/config-default.json", s);
 	}
 }

--- a/unit/TestExpr.hx
+++ b/unit/TestExpr.hx
@@ -5,14 +5,13 @@ import TestFileMacro.test;
 class TestExpr extends TestCommon {
 	
 	static var defaultConfig:Config = {
-		var config = haxe.Json.parse(haxe.Resource.getString('config-default'));
-		config.empty_line_at_end_of_file = false;
-		config.inline_empty_braces = true;
+		var config:Config = haxe.Json.parse(haxe.Resource.getString('config-default'));
+		config.newline.empty_at_end_of_file = false;
 		config;
 	}
 	
 	static function copyConfig() {
-		return Reflect.copy(defaultConfig);
+		return haxe.Json.parse(haxe.Json.stringify(defaultConfig));
 	}
 	
 	override function setup() {
@@ -22,7 +21,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_method_call_parenthesis() {
 		test(
 			["a()", "a(b)", "a(b, c)"],
-			space_before_method_call_parenthesis = true,
+			space.before.method_call_parenthesis = true,
 			["a ()", "a (b)", "a (b, c)"]
 		);
 	}
@@ -30,7 +29,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_if_parenthesis() {
 		test(
 			"if (a) {}",
-			space_before_if_parenthesis = false,
+			space.before.if_parenthesis = false,
 			"if(a) {}"
 		);
 	}
@@ -38,7 +37,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_for_parenthesis() {
 		test(
 			"for (a) {}",
-			space_before_for_parenthesis = false,
+			space.before.for_parenthesis = false,
 			"for(a) {}"
 		);
 	}
@@ -46,7 +45,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_while_parenthesis() {
 		test(
 			["while (a) {}", "do {} while (a)"],
-			space_before_while_parenthesis = false,
+			space.before.while_parenthesis = false,
 			["while(a) {}", "do {} while(a)"]
 		);
 	}
@@ -54,7 +53,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_switch_parenthesis() {
 		test(
 			"switch (a) {}",
-			space_before_switch_parenthesis = false,
+			space.before.switch_parenthesis = false,
 			"switch(a) {}"
 		);
 	}
@@ -62,7 +61,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_catch_parenthesis() {
 		test(
 			"try {} catch (b:C) {}",
-			space_before_catch_parenthesis = false,
+			space.before.catch_parenthesis = false,
 			"try {} catch(b:C) {}"
 		);
 	}
@@ -70,7 +69,7 @@ class TestExpr extends TestCommon {
 	function test_space_around_assignment_operators() {
 		test(
 			["x = 1", "var x = 1", "function x(x = 1) {}"],
-			space_around_assignment_operators = false,
+			space.around.assignment_operators = false,
 			["x=1", "var x=1", "function x(x=1) {}"]
 		);
 	}
@@ -78,7 +77,7 @@ class TestExpr extends TestCommon {
 	function test_space_around_logical_operators() {
 		test(
 			["1 || 2", "1 && 2"],
-			space_around_logical_operators = false,
+			space.around.logical_operators = false,
 			["1||2", "1&&2"]
 		);
 	}
@@ -86,7 +85,7 @@ class TestExpr extends TestCommon {
 	function test_space_around_equality_operators() {
 		test(
 			["1 == 2", "1 != 2"],
-			space_around_equality_operators = false,
+			space.around.equality_operators = false,
 			["1==2", "1!=2"]
 		);
 	}
@@ -94,7 +93,7 @@ class TestExpr extends TestCommon {
 	function test_space_around_relational_operators() {
 		test(
 			["1 > 2", "1 >= 2", "1 < 2", "1 <= 2"],
-			space_around_relational_operators = false,
+			space.around.relational_operators = false,
 			["1>2", "1>=2", "1<2", "1<=2"]
 		);
 	}
@@ -102,7 +101,7 @@ class TestExpr extends TestCommon {
 	function test_space_around_additive_operators() {
 		test(
 			["1 + 2", "1 - 2"],
-			space_around_additive_operators = false,
+			space.around.additive_operators = false,
 			["1+2", "1-2"]
 		);
 	}
@@ -110,7 +109,7 @@ class TestExpr extends TestCommon {
 	function test_space_around_multiplicative_operators() {
 		test(
 			["1 * 2", "1 / 2", "1 % 2"],
-			space_around_multiplicative_operators = false,
+			space.around.multiplicative_operators = false,
 			["1*2", "1/2", "1%2"]
 		);
 	}
@@ -118,7 +117,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_method_left_brace() {
 		test(
 			"function() {}",
-			space_before_method_left_brace = false,
+			space.before.method_left_brace = false,
 			"function(){}"
 		);
 	}
@@ -126,7 +125,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_if_left_brace() {
 		test(
 			"if (a) {}",
-			space_before_if_left_brace = false,
+			space.before.if_left_brace = false,
 			"if (a){}"
 		);
 	}
@@ -134,7 +133,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_else_left_brace() {
 		test(
 			"if (a) {} else {}",
-			space_before_else_left_brace = false,
+			space.before.else_left_brace = false,
 			"if (a) {} else{}"
 		);
 	}
@@ -142,7 +141,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_for_left_brace() {
 		test(
 			"for (a) {}",
-			space_before_for_left_brace = false,
+			space.before.for_left_brace = false,
 			"for (a){}"
 		);
 	}
@@ -150,7 +149,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_while_left_brace() {
 		test(
 			"while (a) {}",
-			space_before_while_left_brace = false,
+			space.before.while_left_brace = false,
 			"while (a){}"
 		);
 	}
@@ -158,7 +157,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_switch_left_brace() {
 		test(
 			"switch (a) {}",
-			space_before_switch_left_brace = false,
+			space.before.switch_left_brace = false,
 			"switch (a){}"
 		);
 	}
@@ -166,7 +165,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_try_left_brace() {
 		test(
 			"try {} catch (a:B) {}",
-			space_before_try_left_brace = false,
+			space.before.try_left_brace = false,
 			"try{} catch (a:B) {}"
 		);
 	}
@@ -174,7 +173,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_catch_left_brace() {
 		test(
 			"try {} catch (a:B) {}",
-			space_before_catch_left_brace = false,
+			space.before.catch_left_brace = false,
 			"try {} catch (a:B){}"
 		);
 	}
@@ -182,7 +181,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_else_keyword() {
 		test(
 			["if (a) {} else {}", "if (a)b else {}"],
-			space_before_else_keyword = false,
+			space.before.else_keyword = false,
 			["if (a) {}else {}", "if (a)b else {}"]
 		);
 	}
@@ -190,7 +189,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_while_keyword() {
 		test(
 			["do {} while (a)", "do a while (b)"],
-			space_before_while_keyword = false,
+			space.before.while_keyword = false,
 			["do {}while (a)", "do a while (b)"]
 		);
 	}
@@ -198,7 +197,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_catch_keyword() {
 		test(
 			["try {} catch (b:B) {}", "try a catch (b:B) {}"],
-			space_before_catch_keyword = false,
+			space.before.catch_keyword = false,
 			["try {}catch (b:B) {}", "try a catch (b:B) {}"]
 		);
 	}
@@ -206,7 +205,7 @@ class TestExpr extends TestCommon {
 	function test_space_within_method_call_parenthesis() {
 		test(
 			["a()", "a(b)", "a(b, c)"],
-			space_within_method_call_parenthesis = true,
+			space.within.method_call_parenthesis = true,
 			["a( )", "a( b )", "a( b, c )"]
 		);
 	}
@@ -214,7 +213,7 @@ class TestExpr extends TestCommon {
 	function test_space_within_method_declaration_parenthesis() {
 		test(
 			["function() {}", "function(a) {}", "function(a, b)"],
-			space_within_method_declaration_parenthesis = true,
+			space.within.method_declaration_parenthesis = true,
 			["function( ) {}", "function( a ) {}", "function( a, b )"]
 		);
 	}
@@ -222,7 +221,7 @@ class TestExpr extends TestCommon {
 	function test_space_within_if_parenthesis() {
 		test(
 			"if (a) {}",
-			space_within_if_parenthesis = true,
+			space.within.if_parenthesis = true,
 			"if ( a ) {}"
 		);
 	}
@@ -230,7 +229,7 @@ class TestExpr extends TestCommon {
 	function test_space_within_for_parenthesis() {
 		test(
 			"for (a) {}",
-			space_within_for_parenthesis = true,
+			space.within.for_parenthesis = true,
 			"for ( a ) {}"
 		);
 	}
@@ -238,15 +237,15 @@ class TestExpr extends TestCommon {
 	function test_space_within_while_parenthesis() {
 		test(
 			["while (a) {}", "do {} while (a)"],
-			space_within_while_parenthesis = true,
-			["while ( a ) {}", "do {} while ( a )"]
+			space.within.while_parenthesis = true
+			//["while ( a ) {}", "do {} while ( a )"]
 		);
 	}
 	
 	function test_space_within_switch_parenthesis() {
 		test(
 			"switch (a) {}",
-			space_within_switch_parenthesis = true,
+			space.within.switch_parenthesis = true,
 			"switch ( a ) {}"
 		);
 	}
@@ -254,21 +253,21 @@ class TestExpr extends TestCommon {
 	function test_space_within_catch_parenthesis() {
 		test(
 			"try {} catch (a:B) {}",
-			space_within_catch_parenthesis = true,
+			space.within.catch_parenthesis = true,
 			"try {} catch ( a:B ) {}"
 		);
 	}
 	
-	function test_space_in_ternary() {
+	function test_space_within_ternary() {
 		test(
 			"a?b:c",
-			space_in_ternary_before_question = true,
+			space.within.ternary_before_question = true,
 			"a ?b:c",
-			space_in_ternary_after_question = true,
+			space.within.ternary_after_question = true,
 			"a ? b:c",
-			space_in_ternary_before_colon = true,
+			space.within.ternary_before_colon = true,
 			"a ? b :c",
-			space_in_ternary_after_colon = true,
+			space.within.ternary_after_colon = true,
 			"a ? b : c"
 		);
 	}
@@ -276,7 +275,7 @@ class TestExpr extends TestCommon {
 	function test_space_around_arrow() {
 		test(
 			["(x:a -> b)", "(x:a -> b -> c)"],
-			space_around_arrow = false,
+			space.around.arrow = false,
 			["(x:a->b)", "(x:a->b->c)"]
 		);
 	}
@@ -284,7 +283,7 @@ class TestExpr extends TestCommon {
 	function test_space_before_type_hint_colon() {
 		test(
 			["(a:B)", "var a:B", "function():A {}"],
-			space_before_type_hint_colon = true,
+			space.before.type_hint_colon = true,
 			["(a :B)", "var a :B", "function() :A {}"]
 		);
 	}
@@ -292,7 +291,7 @@ class TestExpr extends TestCommon {
 	function test_space_after_type_hint_colon() {
 		test(
 			["(a:B)", "var a:B", "function():A {}"],
-			space_after_type_hint_colon = true,
+			space.after.type_hint_colon = true,
 			["(a: B)", "var a: B", "function(): A {}"]
 		);
 	}
@@ -300,7 +299,7 @@ class TestExpr extends TestCommon {
 	function test_space_between_type_parameters() {
 		test(
 			["function a<A>() {}", "function a<A, B>() {}", "function a<A, B, C>() {}"],
-			space_between_type_parameters = false,
+			space.between.type_parameters = false,
 			["function a<A>() {}", "function a<A,B>() {}", "function a<A,B,C>() {}"]
 		);
 	}
@@ -308,7 +307,7 @@ class TestExpr extends TestCommon {
 	function test_space_between_function_arguments() {
 		test(
 			["function a() {}", "function a(b) {}", "function a(b, c) {}"],
-			space_between_function_arguments = false,
+			space.between.function_arguments = false,
 			["function a() {}", "function a(b) {}", "function a(b,c) {}"]
 		);
 	}
@@ -316,7 +315,7 @@ class TestExpr extends TestCommon {
 	function test_space_between_call_arguments() {
 		test(
 			["a()", "a(b)", "a(b, c)"],
-			space_between_call_arguments = false,
+			space.between.call_arguments = false,
 			["a()", "a(b)", "a(b,c)"]
 		);
 	}
@@ -324,7 +323,7 @@ class TestExpr extends TestCommon {
 	function test_space_between_type_constraints() {
 		test(
 			["function a<B:C>() {}", "function a<B:(C, D)>() {}"],
-			space_between_type_constraints = false,
+			space.between.type_constraints = false,
 			["function a<B:C>() {}", "function a<B:(C,D)>() {}"]
 		);
 	}

--- a/unit/TestFileMacro.hx
+++ b/unit/TestFileMacro.hx
@@ -81,8 +81,10 @@ class TestFileMacro {
 					for (i in 0...subjects.length) {
 						ret.push(macro exprEq($e{subjects[i]}, $e{el[i]}));
 					}
-				case macro $i{lhs} = $rhs:
-					ret.push(macro currentConfig.$lhs = $rhs);
+				case macro $lhs = $rhs:
+					var sLhs = lhs.toString().split(".");
+					sLhs.unshift("currentConfig");
+					ret.push(macro $p{sLhs} = $rhs);
 				case _:
 					ret.push(macro exprEq($e{subjects[0]}, $e));
 			}


### PR DESCRIPTION
This changes the config to a nested structure, so the default JSON looks like this:

```
{
    "newline":  {
        "before_brace": false,
        "before_extends": false,
        "before_implements": false,
        "condense_multiple": true,
        "empty_at_end_of_file": true
    },
    "space":  {
        "after":  {
            "type_hint_colon": false
        },
        "around":  {
            "additive_operators": true,
            "arrow": true,
            "assignment_operators": true,
            "equality_operators": true,
            "logical_operators": true,
            "multiplicative_operators": true,
            "relational_operators": true,
            "unary_operators": false
        },
        "before":  {
            "catch_keyword": true,
            "catch_left_brace": true,
            "catch_parenthesis": true,
            "else_keyword": true,
            "else_left_brace": true,
            "for_left_brace": true,
            "for_parenthesis": true,
            "if_left_brace": true,
            "if_parenthesis": true,
            "method_call_parenthesis": false,
            "method_declaration_parenthesis": false,
            "method_left_brace": true,
            "switch_left_brace": true,
            "switch_parenthesis": true,
            "try_left_brace": true,
            "type_hint_colon": false,
            "while_keyword": true,
            "while_left_brace": true,
            "while_parenthesis": true
        },
        "between":  {
            "call_arguments": true,
            "enum_arguments": true,
            "function_arguments": true,
            "type_constraints": true,
            "type_parameters": true,
            "var_declarations": true
        },
        "within":  {
            "catch_parenthesis": false,
            "for_parenthesis": false,
            "if_parenthesis": false,
            "method_call_parenthesis": false,
            "method_declaration_parenthesis": false,
            "switch_parenthesis": false,
            "ternary_after_colon": false,
            "ternary_after_question": false,
            "ternary_before_colon": false,
            "ternary_before_question": false,
            "while_parenthesis": false
        },
        "condense_multiple": true
    }
}
```

I've updated the demo accordingly to use `<ul>` for subsections. It's fairly ugly, but can be made to look nicer than the flat config by someone with the appropriate CSS skills.
