### PR TITLE
skip tokens in #elseif and #else

### DIFF
--- a/src/haxeprinter/Formatter.hx
+++ b/src/haxeprinter/Formatter.hx
@@ -168,10 +168,29 @@ class Formatter extends hxparse.Parser<HaxeLexer, Token> implements hxparse.Pars
 						throw "String expected";
 				}
 				peek(0);
-			case Sharp(s = "if" | "elseif"):
+			case Sharp(s = "if"):
 				addNext(SMacro);
 				skipMacroCond();
 				peek(0);
+			case Sharp(s = "elseif" | "else"):
+				addNext(SMacro);
+				var count = 1;
+				while(true) {
+					var tok = super.peek(0);
+					junk();
+					addLast();
+					switch(tok.tok) {
+						case Sharp("end"):
+							--count;
+							if (count == 0) {
+								return peek(0);
+							}
+						case Sharp("if"):
+							++count;
+						case _:
+					}
+				}
+				throw 'Unclosed macro';
 			case Sharp(_):
 				addNext(SMacro);
 				peek(0);

--- a/unit/TestExpr.hx
+++ b/unit/TestExpr.hx
@@ -327,6 +327,12 @@ class TestExpr extends TestCommon {
 			["function a<B:C>() {}", "function a<B:(C,D)>() {}"]
 		);
 	}
+	
+	function testPreprocessor() {
+		test(
+			["function #if true foo #elseif false bar #else baz #end() {}"]
+		);
+	}
 
 	// TODO: space_between_var_declarations (requires blocks)
 }


### PR DESCRIPTION
Note that tokens in these areas are not formatted. I can't think of a way of supporting that at all with the current structure we have. 
